### PR TITLE
libpirate: allow optional port numbers for TCP and UDP sockets

### DIFF
--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -36,9 +36,9 @@
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 
 static pirate_channel_t readers[PIRATE_NUM_CHANNELS] = {
-    {0, PIPE, NULL, 0, 0, 0, NULL, 0}};
+    {0, PIPE, NULL, 0, 0, 0, 0, NULL, 0}};
 static pirate_channel_t writers[PIRATE_NUM_CHANNELS] = {
-    {0, PIPE, NULL, 0, 0, 0, NULL, 0}};
+    {0, PIPE, NULL, 0, 0, 0, 0, NULL, 0}};
 
 // gaps descriptors must be opened from smallest to largest
 int pirate_open(int gd, int flags) {
@@ -527,6 +527,24 @@ int pirate_get_pathname(int gd, char *pathname) {
     strncpy(pathname, readers[gd].pathname, PIRATE_LEN_NAME);
   }
   return 0;
+}
+
+int pirate_set_port_number(int gd, int port) {
+  if (gd < 0 || gd >= PIRATE_NUM_CHANNELS) {
+    errno = EBADF;
+    return -1;
+  }
+  readers[gd].port_number = port;
+  writers[gd].port_number = port;
+  return 0;
+}
+
+int pirate_get_port_number(int gd) {
+  if (gd < 0 || gd >= PIRATE_NUM_CHANNELS) {
+    errno = EBADF;
+    return -1;
+  }
+  return readers[gd].port_number;
 }
 
 int pirate_set_buffer_size(int gd, int buffer_size) {

--- a/libpirate/primitives.h
+++ b/libpirate/primitives.h
@@ -47,14 +47,16 @@ typedef enum {
   // where %d is the gaps descriptor.
   UNIX_SOCKET,
   // The gaps channel is implemented by using TCP sockets.
-  // The port number is (26427 + d) where d is the gaps descriptor.
   // The writer must use pirate_set_pathname(int, char *)
   // to specify the hostname.
+  // The port number is specified using pirate_set_port_number(int, int)
+  // or defaults to (26427 + d) where d is the gaps descriptor.
   TCP_SOCKET,
   // The gaps channel is implemented by using UDP sockets.
-  // The port number is (26427 + d) where d is the gaps descriptor.
   // The writer must use pirate_set_pathname(int, char *)
   // to specify the hostname.
+  // The port number is specified using pirate_set_port_number(int, int)
+  // or defaults to (26427 + d) where d is the gaps descriptor.
   UDP_SOCKET,
   // The gaps channel is implemented using shared memory.
   // This feature is disabled by default. It must be enabled
@@ -80,6 +82,7 @@ typedef struct {
   int fd;                       // file descriptor
   channel_t channel;            // channel type
   char *pathname;               // optional device path
+  int port_number;              // optional port number (TCP_SOCKET or UDP_SOCKET)
   int buffer_size;              // optional memory buffer size
   size_t packet_size;           // optional packet size (SHMEM_UDP)
   size_t packet_count;          // optional packet count (SHMEM_UDP)
@@ -138,19 +141,32 @@ int pirate_set_channel_type(int gd, channel_t channel_type);
 // of the channel descriptor. Returns INVALID on error.
 channel_t pirate_get_channel_type(int gd);
 
-// Sets the pathname for the read and write ends
+// Sets the pathname or hostname for the read and write ends
 // of the gaps descriptor. Only valid if the channel
-// type is DEVICE. Returns zero on success.
+// type is DEVICE, TCP_SOCKET, or UDP_SOCKET. Returns zero on success.
 // On error -1 is returned, and errno is set appropriately.
 // If pathname is NULL, then the memory allocated
 // for the channel pathname is free'd.
 int pirate_set_pathname(int gd, const char *pathname);
 
-// Gets the pathname for the read and write ends
+// Gets the pathname or hostname for the read and write ends
 // of the gaps descriptor. There must be PIRATE_LEN_NAME
 // bytes allocated at pathname. Returns zero on success.
 // On error -1 is returned, and errno is set appropriately.
 int pirate_get_pathname(int gd, char *pathname);
+
+// Sets the port number for the read and write ends
+// of the gaps descriptor. Only valid if the channel
+// type is TCP_SOCKET or UDP_SOCKET. Returns zero on success.
+// On error -1 is returned, and errno is set appropriately.
+// If pathname is NULL, then the memory allocated
+// for the channel pathname is free'd.
+int pirate_set_port_number(int gd, int port);
+
+// Gets the port number for the read and write ends
+// of the gaps descriptor. On error -1 is returned,
+// and errno is set appropriately.
+int pirate_get_port_number(int gd);
 
 // Sets the memory buffer size for the gaps channel.
 // Only valid if the channel type is SHMEM or UNIX_SOCKET.

--- a/libpirate/test/primitives_test.c
+++ b/libpirate/test/primitives_test.c
@@ -228,24 +228,30 @@ SUITE(pirate_tcp_sockets) {
     char pathname[PIRATE_LEN_NAME];
     memset(pathname, 0, PIRATE_LEN_NAME);
     channel_t prev = pirate_get_channel_type(HIGH_TO_LOW_CH);
+    int prev_port = pirate_get_port_number(HIGH_TO_LOW_CH);
     pirate_get_pathname(HIGH_TO_LOW_CH, pathname);
     pirate_set_channel_type(HIGH_TO_LOW_CH, TCP_SOCKET);
     pirate_set_pathname(HIGH_TO_LOW_CH, "127.0.0.1");
+    pirate_set_port_number(HIGH_TO_LOW_CH, 2626);
     RUN_TEST(test_communication_pthread);
     pirate_set_channel_type(HIGH_TO_LOW_CH, prev);
     pirate_set_pathname(HIGH_TO_LOW_CH, pathname);
+    pirate_set_port_number(HIGH_TO_LOW_CH, prev_port);
 }
 
 SUITE(pirate_udp_sockets) {
     char pathname[PIRATE_LEN_NAME];
     memset(pathname, 0, PIRATE_LEN_NAME);
     channel_t prev = pirate_get_channel_type(HIGH_TO_LOW_CH);
+    int prev_port = pirate_get_port_number(HIGH_TO_LOW_CH);
     pirate_get_pathname(HIGH_TO_LOW_CH, pathname);
     pirate_set_channel_type(HIGH_TO_LOW_CH, UDP_SOCKET);
     pirate_set_pathname(HIGH_TO_LOW_CH, "127.0.0.1");
+    pirate_set_port_number(HIGH_TO_LOW_CH, 0);
     RUN_TEST(test_communication_pthread);
     pirate_set_channel_type(HIGH_TO_LOW_CH, prev);
     pirate_set_pathname(HIGH_TO_LOW_CH, pathname);
+    pirate_set_port_number(HIGH_TO_LOW_CH, prev_port);
 }
 
 SUITE(pirate_pthread_shmem) {

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -17,7 +17,7 @@
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 
 static int udp_socket_reader_open(int gd, pirate_channel_t *channels) {
-  int fd, rv, err, enable, buffer_size;
+  int fd, rv, err, enable, port, buffer_size;
   struct sockaddr_in addr;
 
   fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -25,10 +25,15 @@ static int udp_socket_reader_open(int gd, pirate_channel_t *channels) {
     return fd;
   }
 
+  port = channels[gd].port_number;
+  if (port <= 0) {
+    port = PIRATE_PORT_NUMBER + gd;
+  }
+
   memset(&addr, 0, sizeof(struct sockaddr_in));
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  addr.sin_port = htons(PIRATE_PORT_NUMBER + gd);
+  addr.sin_port = htons(port);
 
   enable = 1;
   rv = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
@@ -63,12 +68,17 @@ static int udp_socket_reader_open(int gd, pirate_channel_t *channels) {
 }
 
 static int udp_socket_writer_open(int gd, pirate_channel_t *channels) {
-  int fd, rv, buffer_size, err;
+  int fd, rv, port, buffer_size, err;
   struct sockaddr_in addr;
 
   fd = socket(AF_INET, SOCK_DGRAM, 0);
   if (fd < 0) {
     return fd;
+  }
+
+  port = channels[gd].port_number;
+  if (port <= 0) {
+    port = PIRATE_PORT_NUMBER + gd;
   }
 
   buffer_size = channels[gd].buffer_size;
@@ -86,7 +96,7 @@ static int udp_socket_writer_open(int gd, pirate_channel_t *channels) {
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = inet_addr(channels[gd].pathname);
-  addr.sin_port = htons(PIRATE_PORT_NUMBER + gd);
+  addr.sin_port = htons(port);
   rv = connect(fd, (const struct sockaddr*) &addr, sizeof(addr));
 
   if (rv < 0) {


### PR DESCRIPTION
Add API to specify the port number for TCP and UDP channels. If port number is not specified then fallback to the default behavior of (26427 + d) where d is the gaps descriptor.